### PR TITLE
When the eWalletCode is set to ALIPAYPLUS, the subEWalletCode must be…

### DIFF
--- a/docs/Payment/OrderCreation/_e-wallet.md
+++ b/docs/Payment/OrderCreation/_e-wallet.md
@@ -48,6 +48,8 @@
 
   Secondary E-Wallet Code 
 
+  When the eWalletCode is set to ALIPAYPLUS, the subEWalletCode must be required
+
   Example value: 
 
     `ALIPAYALL` . All Alipay plus wallets 


### PR DESCRIPTION
When the eWalletCode is set to ALIPAYPLUS, the subEWalletCode must be required